### PR TITLE
Explicitly coerce XML element name as QName.

### DIFF
--- a/src/io/arkeus/tiled/TiledMap.as
+++ b/src/io/arkeus/tiled/TiledMap.as
@@ -51,7 +51,7 @@ package io.arkeus.tiled {
 			// between them can be very important. WHY BJORN, WHY?
 			var elements:XMLList = tmx.children();
 			for (var i:uint = 0; i < elements.length(); i++) {
-				var name:QName = (elements[i] as XML).name();
+				var name:QName = ((elements[i] as XML).name() as QName);
 				if (name.localName == "layer") {
 					layers.addLayer(new TiledTileLayer(elements[i]));
 				} else if (name.localName == "objectgroup") {


### PR DESCRIPTION
FlashDevelop was complaining about an implicit coercion. So I made it explicit. And we all lived happily ever after...
