### PR TITLE
Fix TiledTileset to correctly identify tile width and height

### DIFF
--- a/src/io/arkeus/tiled/TiledTileset.as
+++ b/src/io/arkeus/tiled/TiledTileset.as
@@ -27,54 +27,54 @@ package io.arkeus.tiled {
 		public var terrain:Object;
 		/** A map from gid to tile for all the non-standard tiles in the tileset. */
 		public var tiles:Object;
-		
+
 		public function TiledTileset(tmx:XML) {
 			firstGid = tmx.@firstgid;
 			name = tmx.@name;
-			tileWidth = tmx.@tileWidth;
-			tileHeight = tmx.@tileHeight;
+			tileWidth = tmx.@tilewidth;
+			tileHeight = tmx.@tileheight;
 			spacing = "@spacing" in tmx ? tmx.@spacing : 0;
 			margin = "@margin" in tmx ? tmx.@margin : 0;
-			
+
 			var offset:XMLList = tmx.tileoffset;
 			tileOffset = offset.length() == 1 ? new Point(offset.@x, offset.@y) : new Point;
-			
+
 			image = new TiledImage(tmx.image);
 			terrain = loadTerrain(tmx.terraintypes);
 			tiles = loadTiles(tmx.tile);
 		}
-		
+
 		/**
 		 * Given a tileset, loads all the terrains from the terraintypes object.
-		 * 
+		 *
 		 * @param tmx The terraintypes object.
 		 * @return The map from terrain name to terrain.
 		 */
 		private static function loadTerrain(tmx:XMLList):Object {
 			var terrain:Object = {};
-			
+
 			for (var i:uint = 0; i < tmx.terrain.length(); i++) {
 				var node:TiledTerrain = new TiledTerrain(tmx.terrain[i]);
 				terrain[node.name] = node;
 			}
-			
+
 			return terrain;
 		}
-		
+
 		/**
 		 * Given a list of tiles, builds a map from gid to tile.
-		 * 
+		 *
 		 * @param tmx The XMLList of <tile> objects.
 		 * @return The map from gid to tiles.
 		 */
 		private static function loadTiles(tmx:XMLList):Object {
 			var tiles:Object = {};
-			
+
 			for (var i:uint = 0; i < tmx.length(); i++) {
 				var node:TiledTile = new TiledTile(tmx[i]);
 				tiles[node.id] = node;
 			}
-			
+
 			return tiles;
 		}
 	}


### PR DESCRIPTION
The TMX format uses all lowercase for these attribute names:

```
<tileset firstgid="1" name="Caves" tilewidth="128" tileheight="128">
```
